### PR TITLE
Use -onbuild variant of pangeo image as base

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,2 +1,2 @@
 # Note that there must be a tag
-FROM pangeo/pangeo-notebook:2019.04.19
+FROM pangeo/pangeo-notebook-onbuild:2019.04.19

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,15 +1,2 @@
 # Note that there must be a tag
 FROM pangeo/pangeo-notebook:2019.04.19
-
-# https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html#preparing-your-dockerfile
-ENV NB_USER jovyan
-ENV NB_UID 1000
-ENV HOME /home/${NB_USER}
-
-COPY . ${HOME}
-USER root
-RUN chown -R ${NB_UID} ${HOME}
-USER ${NB_USER}
-
-# is this the best way to do this?
-RUN pip install git+https://github.com/rabernat/xbatcher.git


### PR DESCRIPTION
- mybinder.org style extra lines in Dockerfile are not needed when
  using the -onbuild variants of images
- environment.yml file has the pip package to be installed, so that
  can also be removed from Dockerfile
- Explicitly specify that the onbuild variant is to be used